### PR TITLE
Use url_param_only instead of virtual field.

### DIFF
--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -97,10 +97,6 @@ module Api
 
       # A pattern that maps expected user input to expected API input.
       attr_reader :pattern
-
-      # Used in the schema to indicate if a change in a field requires
-      # the resource to be destroyed and recreated.
-      attr_reader :force_new
     end
 
     include Fields
@@ -136,7 +132,6 @@ module Api
       check :update_id, type: ::String
       check :fingerprint_name, type: ::String
       check :pattern, type: ::String
-      check :force_new, type: :boolean
 
       check_default_value_property
       check_conflicts

--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -171,6 +171,12 @@ objects:
                     description: |
                       Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                       the extension will be omitted from the CA certificate.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'includeMaxIssuerPathLength'
+                    url_param_only: true
+                    description: |
+                      Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
+                      If not set, max_issuer_path_length will be unset.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |
@@ -982,10 +988,22 @@ objects:
                 Describes values that are relevant in a CA certificate.
               properties:
                 - !ruby/object:Api::Type::Boolean
+                  name: 'includeIsCa'
+                  url_param_only: true
+                  description: |
+                    Must be set to use the value of is_ca, either true or false. If not set, is_ca will
+                    be unset.
+                - !ruby/object:Api::Type::Boolean
                   name: 'isCa'
                   description: |
                     Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                     the extension will be omitted from the CA certificate.
+                - !ruby/object:Api::Type::Boolean
+                  name: 'includeMaxIssuerPathLength'
+                  url_param_only: true
+                  description: |
+                    Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
+                    If not set, max_issuer_path_length will be unset.
                 - !ruby/object:Api::Type::Integer
                   name: 'maxIssuerPathLength'
                   description: |
@@ -1409,10 +1427,22 @@ objects:
                   Describes values that are relevant in a CA certificate.
                 properties:
                   - !ruby/object:Api::Type::Boolean
+                    name: 'includeIsCa'
+                    url_param_only: true
+                    description: |
+                      Must be set to use the value of is_ca, either true or false. If not set, is_ca will
+                      be unset.
+                  - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     description: |
                       Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                       the extension will be omitted from the CA certificate.
+                  - !ruby/object:Api::Type::Boolean
+                    name: 'includeMaxIssuerPathLength'
+                    url_param_only: true
+                    description: |
+                      Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
+                      If not set, max_issuer_path_length will be unset.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -54,14 +54,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           kms_key_name: 'BootstrapKMSKeyWithPurposeInLocation(t, "ASYMMETRIC_SIGN", "us-central1").CryptoKey.Name'
           pool_name: 'BootstrapSharedCaPoolInLocation(t, "us-central1")'
           pool_location: "\"us-central1\""
-    virtual_fields:
-      - !ruby/object:Api::Type::Boolean
-        name: 'include_max_path_length'
-        default_value: false
-        description: |
-          Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-          If not set, max_issuer_path_length will be unset.
-        force_new: true
     properties:
       type: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
@@ -88,21 +80,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
 
       ~> **Note:** The Certificate Authority that is referenced by this resource **must** be 
       `tier = "ENTERPRISE"`
-    virtual_fields:
-      - !ruby/object:Api::Type::Boolean
-        name: 'include_is_ca'
-        default_value: false
-        description: |
-          Must be set to use the value of is_ca, either true or false. If not set, is_ca will
-          be unset.
-        force_new: true
-      - !ruby/object:Api::Type::Boolean
-        name: 'include_max_path_length'
-        default_value: false
-        description: |
-          Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-          If not set, max_issuer_path_length will be unset.
-        force_new: true
     properties:
       config.x509Config: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/privateca_certificate_509_config.go.erb'
@@ -161,19 +138,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: 'templates/terraform/custom_expand/privateca_certificate_509_config.go.erb'
       publishingOptions: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'emptyOrUnsetBlockDiffSuppress'
-    virtual_fields:
-      - !ruby/object:Api::Type::Boolean
-        name: 'include_is_ca'
-        default_value: false
-        description: |
-          Must be set to use the value of is_ca, either true or false. If not set, is_ca will
-          be unset.
-      - !ruby/object:Api::Type::Boolean
-        name: 'include_max_path_length'
-        default_value: false
-        description: |
-          Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-          If not set, max_issuer_path_length will be unset.
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       allowed_iam_role: 'roles/privateca.certificateManager'
       method_name_separator: ':'

--- a/mmv1/provider/terraform/virtual_fields.rb
+++ b/mmv1/provider/terraform/virtual_fields.rb
@@ -49,17 +49,12 @@ module Provider
       # The default value for the field (defaults to false)
       attr_reader :default_value
 
-      # Whether or not a change to this field requires the resource to be
-      # destroyed and recreated (defaults to false)
-      attr_reader :force_new
-
       def validate
         super
         check :name, type: String, required: true
         check :description, type: String, required: true
         check :type, type: Class, default: Api::Type::Boolean
         check :default_value, default: false
-        check :force_new, type: :boolean, default: false
       end
     end
   end

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -9,8 +9,6 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
   labels = {
     foo = "bar"
   }
-  include_is_ca = true
-  include_max_path_length = true
   issuance_policy {
     allowed_key_types {
       elliptic_curve {
@@ -52,7 +50,9 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
         object_id_path = [1, 5, 7]
       }
       ca_options {
+        include_is_ca = true
         is_ca = true
+        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -4,8 +4,6 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   pool = "<%= ctx[:vars]["pool_name"] %>"
   certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
   location = "<%= ctx[:vars]["pool_location"] %>"
-  # Required to set max_issuer_path_length to 0
-  include_max_path_length = true
   config {
     subject_config {
       subject {
@@ -20,6 +18,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
       ca_options {
         is_ca = true
         # Force the sub CA to only issue leaf certs
+        include_max_issuer_path_length = true
         max_issuer_path_length = 0
       }
       key_usage {

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -114,9 +114,6 @@ func resource<%= resource_name -%>() *schema.Resource {
               Type: <%= tf_type(field) -%>,
               Optional: true,
               Default:  <%= go_literal(field.default_value) -%>,
-              <% if field.force_new -%>
-              ForceNew: true,
-              <% end -%>
             },
 <%        end -%>
 <%      end -%>

--- a/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
@@ -55,8 +55,6 @@ resource "google_privateca_ca_pool" "default" {
   name = "tf-test-my-capool%{random_suffix}"
   location = "us-central1"
   tier = "ENTERPRISE"
-  include_is_ca = true
-  include_max_path_length = true
   publishing_options {
     publish_ca_cert = false
     publish_crl = true
@@ -105,7 +103,9 @@ resource "google_privateca_ca_pool" "default" {
         object_id_path = [1,5,7]
       }
       ca_options {
+	include_is_ca = true
         is_ca = true
+	include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {
@@ -139,8 +139,6 @@ resource "google_privateca_ca_pool" "default" {
   name = "tf-test-my-capool%{random_suffix}"
   location = "us-central1"
   tier = "ENTERPRISE"
-  include_is_ca = true
-  include_max_path_length = true
   publishing_options {
     publish_ca_cert = true
     publish_crl = true
@@ -189,7 +187,9 @@ resource "google_privateca_ca_pool" "default" {
         object_id_path = [1, 7]
       }
       ca_options {
+	include_is_ca = true
         is_ca = true
+	include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -38,20 +38,17 @@ func expandPrivatecaCertificateConfigX509ConfigCaOptions(v interface{}, d Terraf
 	raw := l[0]
 	original := raw.(map[string]interface{})
 
-	includeIsCa := original["include_is_ca"].(bool)
+	includeIsCa := false
+	// For resource CertificateAuthority, there is not a field named `include_is_ca`.
+	if original["include_is_ca"] != nil && original["include_is_ca"].(bool) {
+		includeIsCa = true
+	}
 	isCa := original["is_ca"].(bool)
 
 	includePathLength := original["include_max_issuer_path_length"].(bool)
 	max_issuer_path_length := original["max_issuer_path_length"].(int)
 
 	transformed := make(map[string]interface{})
-
-	//if original["is_ca"].(bool) && !includeIsCa.(bool) {
-	//	return nil, fmt.Errorf("You must set include_is_ca=true with ca_options.is_ca=true")
-	//}
-	//if original["max_issuer_path_length"].(int) > 0 && !includePathLength.(bool) {
-	//	return nil, fmt.Errorf("You must set include_max_path_length=true with ca_options.max_issuer_path_length>0")
-	//}
 
 	if includeIsCa || isCa {
 		transformed["isCa"] = original["is_ca"]
@@ -315,7 +312,9 @@ func flattenPrivatecaCertificateConfigX509ConfigCaOptions(v interface{}, d *sche
 	val, exists := original["isCa"]
 	transformed["is_ca"] =
 		flattenPrivatecaCertificateConfigX509ConfigCaOptionsIsCa(val, d, config)
-	if exists {
+	// CertificateAuthority does not fields `include_is_ca`.
+	// Expecting non-CertificateAuthority resource does not have field `certificate_authority_id` at top level.
+	if exists && d.Get("certificate_authority_id") == nil {
 		transformed["include_is_ca"] = true
 	}
 


### PR DESCRIPTION
* Use url_param_only instead of virtual field.
* Rename new field `includeMaxPathLength` to `includeMaxIssuerPathLength` for local consistence.


# Test cases

## CA_Pool
> x means is_ca or max_issuer_path_length

- include_x set to false, x set to false, expect x not to be set.
- include_x set to false, is_ca set to true, expect is_ca to be updated to true for backward-compatibility
- include_x set to false, max_issuer_path_length set to 1, expect max_issuer_path_length to be updated to 1 for backward-compatibility
- include_x set to true, with a default of 0/false, expect 0/false be set
- include_x set to true, a nondefault, expect nondefault value be udpated
- include_x not set at all, expect works as it set to false

## CA

- Create a CA resource with include_x set to true