### PR TITLE
Rebase hayden for url param only

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -169,7 +169,7 @@ objects:
                     name: 'includeIsCa'
                     url_param_only: true
                     description: |
-                      Must be set to true when isCa is set to false.
+                      Must be set to true to use is_ca.
                   - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     required: true
@@ -180,7 +180,7 @@ objects:
                     name: 'includeMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to true when max_issuer_path_length is set to 0.
+                      Must be set to true to use max_issuer_path_length.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |
@@ -995,7 +995,7 @@ objects:
                   name: 'includeIsCa'
                   url_param_only: true
                   description: |
-                    Must be set to true when isCa is set to false.
+                    Must be set to true to use is_ca.
                 - !ruby/object:Api::Type::Boolean
                   name: 'isCa'
                   description: |
@@ -1005,7 +1005,7 @@ objects:
                   name: 'includeMaxIssuerPathLength'
                   url_param_only: true
                   description: |
-                    Must be set to true when max_issuer_path_length is set to 0.
+                    Must be set to true to use max_issuer_path_length.
                 - !ruby/object:Api::Type::Integer
                   name: 'maxIssuerPathLength'
                   description: |
@@ -1432,7 +1432,7 @@ objects:
                     name: 'includeIsCa'
                     url_param_only: true
                     description: |
-                      Must be set to true when isCa is set to false.
+                      Must be set to true to use is_ca.
                   - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     description: |
@@ -1442,7 +1442,7 @@ objects:
                     name: 'includeMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to true when max_issuer_path_length is set to 0.
+                      Must be set to true to use max_issuer_path_length.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |

--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -166,6 +166,11 @@ objects:
                   Describes values that are relevant in a CA certificate.
                 properties:
                   - !ruby/object:Api::Type::Boolean
+                    name: 'includeIsCa'
+                    url_param_only: true
+                    description: |
+                      Must be set to true when isCa is set to false.
+                  - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     required: true
                     description: |
@@ -175,8 +180,7 @@ objects:
                     name: 'includeMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-                      If not set, max_issuer_path_length will be unset.
+                      Must be set to true when max_issuer_path_length is set to 0.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |
@@ -991,8 +995,7 @@ objects:
                   name: 'includeIsCa'
                   url_param_only: true
                   description: |
-                    Must be set to use the value of is_ca, either true or false. If not set, is_ca will
-                    be unset.
+                    Must be set to true when isCa is set to false.
                 - !ruby/object:Api::Type::Boolean
                   name: 'isCa'
                   description: |
@@ -1002,8 +1005,7 @@ objects:
                   name: 'includeMaxIssuerPathLength'
                   url_param_only: true
                   description: |
-                    Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-                    If not set, max_issuer_path_length will be unset.
+                    Must be set to true when max_issuer_path_length is set to 0.
                 - !ruby/object:Api::Type::Integer
                   name: 'maxIssuerPathLength'
                   description: |
@@ -1430,8 +1432,7 @@ objects:
                     name: 'includeIsCa'
                     url_param_only: true
                     description: |
-                      Must be set to use the value of is_ca, either true or false. If not set, is_ca will
-                      be unset.
+                      Must be set to true when isCa is set to false.
                   - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     description: |
@@ -1441,8 +1442,7 @@ objects:
                     name: 'includeMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to use the value of max_issuer_path_length, either 0 or greater than 0.
-                      If not set, max_issuer_path_length will be unset.
+                      Must be set to true when max_issuer_path_length is set to 0.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -16,7 +16,9 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     }
     x509_config {
       ca_options {
+        include_is_ca = true
         is_ca = true
+        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -39,7 +39,9 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
+        include_is_ca = true
         is_ca = true
+        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -16,6 +16,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     }
     x509_config {
       ca_options {
+        include_is_ca = true
         is_ca = true
         # Force the sub CA to only issue leaf certs
         include_max_issuer_path_length = true

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -15,6 +15,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
     }
     x509_config {
       ca_options {
+        include_is_ca = true
         is_ca = true
       }
       key_usage {
@@ -58,6 +59,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
+        include_is_ca = ture
         is_ca = false
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
@@ -15,6 +15,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
+        include_is_ca = true
         is_ca = true
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
@@ -16,6 +16,7 @@ resource "google_privateca_certificate_authority" "authority" {
     }
     x509_config {
       ca_options {
+        include_is_ca = true
         is_ca = true
       }
       key_usage {
@@ -57,6 +58,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
+        include_is_ca = true
         is_ca = false
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -36,8 +36,10 @@ resource "google_privateca_certificate_template" "template" {
     aia_ocsp_servers = ["string"]
 
     ca_options {
-      is_ca                  = false
-      max_issuer_path_length = 6
+      include_is_ca                  = true
+      is_ca                          = false
+      include_max_issuer_path_length = true
+      max_issuer_path_length         = 6
     }
 
     key_usage {
@@ -90,6 +92,7 @@ resource "google_privateca_certificate_authority" "test-ca" {
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
+        include_is_ca = true
         is_ca = true
       }
       key_usage {

--- a/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
@@ -322,3 +322,129 @@ resource "google_privateca_ca_pool" "default" {
 }
 `, context)
 }
+
+func TestAccPrivatecaCaPool_updateCaOption(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPrivatecaCaPoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCaPool_privatecaCapoolCaOptionAllFieldsAreSpecified(context),
+			},
+			{
+				ResourceName:            "google_privateca_ca_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location"},
+			},
+			{
+				Config: testAccPrivatecaCaPool_privatecaCapoolCaOptionIsCaIsFalse(context),
+			},
+			{
+				ResourceName:            "google_privateca_ca_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location"},
+			},
+			{
+				Config: testAccPrivatecaCaPool_privatecaCapoolCaOptionMaxIssuerPathLenghIsZero(context),
+			},
+			{
+				ResourceName:            "google_privateca_ca_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location"},
+			},
+		},
+	})
+}
+
+func testAccPrivatecaCaPool_privatecaCapoolCaOptionAllFieldsAreSpecified(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_privateca_ca_pool" "default" {
+  name = "tf-test-my-capool%{random_suffix}"
+  location = "us-central1"
+  tier = "ENTERPRISE"
+
+  issuance_policy {
+    baseline_values {
+      ca_options {
+        include_is_ca = true
+        is_ca = true
+        include_max_issuer_path_length = true
+        max_issuer_path_length = 10
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccPrivatecaCaPool_privatecaCapoolCaOptionIsCaIsFalse(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_privateca_ca_pool" "default" {
+  name = "tf-test-my-capool%{random_suffix}"
+  location = "us-central1"
+  tier = "ENTERPRISE"
+
+  issuance_policy {
+    baseline_values {
+      ca_options {
+        include_is_ca = true
+        is_ca = false
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccPrivatecaCaPool_privatecaCapoolCaOptionMaxIssuerPathLenghIsZero(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_privateca_ca_pool" "default" {
+  name = "tf-test-my-capool%{random_suffix}"
+  location = "us-central1"
+  tier = "ENTERPRISE"
+
+  issuance_policy {
+    baseline_values {
+      ca_options {
+        include_max_issuer_path_length = true
+        max_issuer_path_length = 0
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
@@ -103,9 +103,9 @@ resource "google_privateca_ca_pool" "default" {
         object_id_path = [1,5,7]
       }
       ca_options {
-	include_is_ca = true
+        include_is_ca = true
         is_ca = true
-	include_max_issuer_path_length = true
+      	include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -38,11 +38,7 @@ func expandPrivatecaCertificateConfigX509ConfigCaOptions(v interface{}, d Terraf
 	raw := l[0]
 	original := raw.(map[string]interface{})
 
-	includeIsCa := false
-	// For resource CertificateAuthority, there is not a field named `include_is_ca`.
-	if original["include_is_ca"] != nil && original["include_is_ca"].(bool) {
-		includeIsCa = true
-	}
+	includeIsCa := original["include_is_ca"].(bool)
 	isCa := original["is_ca"].(bool)
 
 	includePathLength := original["include_max_issuer_path_length"].(bool)
@@ -312,9 +308,7 @@ func flattenPrivatecaCertificateConfigX509ConfigCaOptions(v interface{}, d *sche
 	val, exists := original["isCa"]
 	transformed["is_ca"] =
 		flattenPrivatecaCertificateConfigX509ConfigCaOptionsIsCa(val, d, config)
-	// CertificateAuthority does not fields `include_is_ca`.
-	// Expecting non-CertificateAuthority resource does not have field `certificate_authority_id` at top level.
-	if exists && d.Get("certificate_authority_id") == nil {
+	if exists {
 		transformed["include_is_ca"] = true
 	}
 

--- a/mmv1/third_party/terraform/utils/privateca_utils.go
+++ b/mmv1/third_party/terraform/utils/privateca_utils.go
@@ -21,7 +21,7 @@ import (
 // Expander utilities
 
 func expandPrivatecaCertificateConfigX509ConfigCaOptions(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	// Fields include_is_ca, include_max_issuer_path_length are used to distinguish between 
+	// Fields include_is_ca, include_max_issuer_path_length are used to distinguish between
 	// unset booleans and booleans set with a default value.
 	// Unset is_ca or unset max_issuer_path_length either allow any values for these fields when
 	// used in an issuance policy, or allow the API to use default values when used in a


### PR DESCRIPTION
* Update description for fields `include_is_ca`, `include_max_issuer_path_path`.
* Add field `include_is_ca` to CertificateAuthority to avoid checking
the existence of this field in flattener.
* Update examples with new fields like `include_is_ca`, `include_max_issuer_path_length`.
* Add more test csaes.
