### PR TITLE
Update semantic meaning for newly added fields to avoid breaking

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -166,10 +166,10 @@ objects:
                   Describes values that are relevant in a CA certificate.
                 properties:
                   - !ruby/object:Api::Type::Boolean
-                    name: 'includeIsCa'
+                    name: 'nonCa'
                     url_param_only: true
                     description: |
-                      Must be set to true to use is_ca.
+                      Must be set to true when is_ca is set to false.
                   - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     required: true
@@ -177,10 +177,10 @@ objects:
                       Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                       the extension will be omitted from the CA certificate.
                   - !ruby/object:Api::Type::Boolean
-                    name: 'includeMaxIssuerPathLength'
+                    name: 'zeroMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to true to use max_issuer_path_length.
+                      Must be set to true when max_issuer_path_length is set to 0.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |
@@ -992,20 +992,20 @@ objects:
                 Describes values that are relevant in a CA certificate.
               properties:
                 - !ruby/object:Api::Type::Boolean
-                  name: 'includeIsCa'
+                  name: 'nonCa'
                   url_param_only: true
                   description: |
-                    Must be set to true to use is_ca.
+                    Must be set to true when is_ca is set to false.
                 - !ruby/object:Api::Type::Boolean
                   name: 'isCa'
                   description: |
                     Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                     the extension will be omitted from the CA certificate.
                 - !ruby/object:Api::Type::Boolean
-                  name: 'includeMaxIssuerPathLength'
+                  name: 'zeroMaxIssuerPathLength'
                   url_param_only: true
                   description: |
-                    Must be set to true to use max_issuer_path_length.
+                    Must be set to true when max_issuer_path_length is set to 0.
                 - !ruby/object:Api::Type::Integer
                   name: 'maxIssuerPathLength'
                   description: |
@@ -1429,20 +1429,20 @@ objects:
                   Describes values that are relevant in a CA certificate.
                 properties:
                   - !ruby/object:Api::Type::Boolean
-                    name: 'includeIsCa'
+                    name: 'nonCa'
                     url_param_only: true
                     description: |
-                      Must be set to true to use is_ca.
+                      Must be set to true when is_ca is set to false.
                   - !ruby/object:Api::Type::Boolean
                     name: 'isCa'
                     description: |
                       Refers to the "CA" X.509 extension, which is a boolean value. When this value is missing,
                       the extension will be omitted from the CA certificate.
                   - !ruby/object:Api::Type::Boolean
-                    name: 'includeMaxIssuerPathLength'
+                    name: 'zeroMaxIssuerPathLength'
                     url_param_only: true
                     description: |
-                      Must be set to true to use max_issuer_path_length.
+                      Must be set to true when max_issuer_path_length is set to 0.
                   - !ruby/object:Api::Type::Integer
                     name: 'maxIssuerPathLength'
                     description: |

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.erb
@@ -50,9 +50,7 @@ resource "google_privateca_ca_pool" "<%= ctx[:primary_resource_id] %>" {
         object_id_path = [1, 5, 7]
       }
       ca_options {
-        include_is_ca = true
         is_ca = true
-        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -16,9 +16,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     }
     x509_config {
       ca_options {
-        include_is_ca = true
         is_ca = true
-        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -39,9 +39,7 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
-        include_is_ca = true
         is_ca = true
-        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.erb
@@ -16,10 +16,9 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
     }
     x509_config {
       ca_options {
-        include_is_ca = true
         is_ca = true
         # Force the sub CA to only issue leaf certs
-        include_max_issuer_path_length = true
+        zero_max_issuer_path_length = true
         max_issuer_path_length = 0
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_config.tf.erb
@@ -15,7 +15,6 @@ resource "google_privateca_certificate_authority" "test-ca" {
     }
     x509_config {
       ca_options {
-        include_is_ca = true
         is_ca = true
       }
       key_usage {
@@ -59,7 +58,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
-        include_is_ca = true
+        non_ca = true
         is_ca = false
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_csr.tf.erb
@@ -15,7 +15,6 @@ resource "google_privateca_certificate_authority" "test-ca" {
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
-        include_is_ca = true
         is_ca = true
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_no_authority.tf.erb
@@ -16,7 +16,6 @@ resource "google_privateca_certificate_authority" "authority" {
     }
     x509_config {
       ca_options {
-        include_is_ca = true
         is_ca = true
       }
       key_usage {
@@ -58,7 +57,7 @@ resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
     }
     x509_config {
       ca_options {
-        include_is_ca = true
+        non_ca = true
         is_ca = false
       }
       key_usage {

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -90,7 +90,6 @@ resource "google_privateca_certificate_authority" "test-ca" {
     x509_config {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
-        include_is_ca = true
         is_ca = true
       }
       key_usage {

--- a/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
+++ b/mmv1/third_party/terraform/tests/resource_privateca_ca_pool_test.go
@@ -103,9 +103,7 @@ resource "google_privateca_ca_pool" "default" {
         object_id_path = [1,5,7]
       }
       ca_options {
-        include_is_ca = true
         is_ca = true
-      	include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {
@@ -187,9 +185,7 @@ resource "google_privateca_ca_pool" "default" {
         object_id_path = [1, 7]
       }
       ca_options {
-	include_is_ca = true
         is_ca = true
-	include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {
@@ -336,7 +332,7 @@ func TestAccPrivatecaCaPool_updateCaOption(t *testing.T) {
 		CheckDestroy: testAccCheckPrivatecaCaPoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivatecaCaPool_privatecaCapoolCaOptionAllFieldsAreSpecified(context),
+				Config: testAccPrivatecaCaPool_privatecaCapoolCaOptionIsCaIsTrueAndMaxPathIsPositive(context),
 			},
 			{
 				ResourceName:            "google_privateca_ca_pool.default",
@@ -366,7 +362,7 @@ func TestAccPrivatecaCaPool_updateCaOption(t *testing.T) {
 	})
 }
 
-func testAccPrivatecaCaPool_privatecaCapoolCaOptionAllFieldsAreSpecified(context map[string]interface{}) string {
+func testAccPrivatecaCaPool_privatecaCapoolCaOptionIsCaIsTrueAndMaxPathIsPositive(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_privateca_ca_pool" "default" {
   name = "tf-test-my-capool%{random_suffix}"
@@ -376,9 +372,7 @@ resource "google_privateca_ca_pool" "default" {
   issuance_policy {
     baseline_values {
       ca_options {
-        include_is_ca = true
         is_ca = true
-        include_max_issuer_path_length = true
         max_issuer_path_length = 10
       }
       key_usage {
@@ -405,7 +399,7 @@ resource "google_privateca_ca_pool" "default" {
   issuance_policy {
     baseline_values {
       ca_options {
-        include_is_ca = true
+        non_ca = true
         is_ca = false
       }
       key_usage {
@@ -432,7 +426,7 @@ resource "google_privateca_ca_pool" "default" {
   issuance_policy {
     baseline_values {
       ca_options {
-        include_max_issuer_path_length = true
+        zero_max_issuer_path_length = true
         max_issuer_path_length = 0
       }
       key_usage {


### PR DESCRIPTION
* User `nonCa`, `zeroMaxIssuerPathLength` instead of `includeIsCa`
`includeMaxIssuerPathLength`
* Update test cases.